### PR TITLE
Allow unused vars if they begin w/ underscore / cap block comments

### DIFF
--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -24,18 +24,18 @@ const defaultFormattingRules = {
 		}
 	],
 	"capitalized-comments": [
-        "error",
-        "always",
-        {
+		"error",
+		"always",
+		{
 			"line": {
-                "ignorePattern": ".*",
-            },
-            "block": {
-                "ignoreInlineComments": true,
-            	"ignoreConsecutiveComments": true
-            }
-        }
-    ]
+				"ignorePattern": ".*",
+			},
+			"block": {
+				"ignoreInlineComments": true,
+				"ignoreConsecutiveComments": true
+			}
+		}
+	]
 }
 
 module.exports = {

--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -11,7 +11,8 @@ const defaultFormattingRules = {
 	'no-undef': 'error',
 	'no-var': 'error',
 	'no-unreachable': 'error',
-	'no-unused-vars': 'error',
+	'no-unused-vars': ['error', {'argsIgnorePattern': '^_'}],
+	'@typescript-eslint/no-unused-vars': ['error', {'argsIgnorePattern': '^_'}],
 	'object-shorthand': ['error', 'always'],
 	'react/prop-types': 'off',
 	'prettier/prettier': [
@@ -26,8 +27,13 @@ const defaultFormattingRules = {
         "error",
         "always",
         {
-            "ignoreInlineComments": true,
-            "ignoreConsecutiveComments": true
+			"line": {
+                "ignorePattern": ".*",
+            },
+            "block": {
+                "ignoreInlineComments": true,
+            	"ignoreConsecutiveComments": true
+            }
         }
     ]
 }


### PR DESCRIPTION
Updates rules:
* No unused vars - Will now allow unused vars if they begin with an underscore to denote that they are unused
  * `function(description: string, ...args: string[])` <-- Error!
  * `function(description: string, ..._args: string[])` <-- Ok!
  
* Capitalized comments
  * Only enforce rules for block comments: `/** something */` <-- Error!
  * Regular comments will now allow lowercase `// something` <-- Ok!