### PR TITLE
Auto-fix pascal case enum / #spruce imports

### DIFF
--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -6,6 +6,7 @@ const defaultFormattingRules = {
 	curly: 'error',
 	'spruce/utils-graphql': 'error',
 	'spruce/prefer-pascal-case-enums': 'error',
+	'spruce/prefer-spruce-hash-import': 'error',
 	'react/jsx-no-undef': 'error',
 	'no-console': 'off',
 	'no-undef': 'error',

--- a/packages/eslint-plugin-spruce/index.js
+++ b/packages/eslint-plugin-spruce/index.js
@@ -1,6 +1,7 @@
 module.exports = {
 	rules: {
 		'utils-graphql': require('./lib/rules/utils-graphql'),
-		'prefer-pascal-case-enums': require('./lib/rules/prefer-pascal-case-enums')
+		'prefer-pascal-case-enums': require('./lib/rules/prefer-pascal-case-enums'),
+		'prefer-spruce-hash-import': require('./lib/rules/prefer-spruce-hash-import')
 	}
 }

--- a/packages/eslint-plugin-spruce/lib/rules/prefer-pascal-case-enums.js
+++ b/packages/eslint-plugin-spruce/lib/rules/prefer-pascal-case-enums.js
@@ -8,7 +8,7 @@ module.exports = {
 			category: 'Stylistic Issues',
 			recommended: false
 		},
-		fixable: null
+		fixable: 'code'
 	},
 	create(context) {
 		function report(node) {
@@ -17,7 +17,10 @@ module.exports = {
 			context.report({
 				node,
 				message: `Enum '{{name}}' should use Pascal case.`,
-				data: { name }
+				data: { name },
+				fix: function(fixer) {
+					return fixer.replaceText(node, pascalCase(name));
+				}
 			})
 		}
 

--- a/packages/eslint-plugin-spruce/lib/rules/prefer-spruce-hash-import.js
+++ b/packages/eslint-plugin-spruce/lib/rules/prefer-spruce-hash-import.js
@@ -1,0 +1,30 @@
+// From https://github.com/Shopify/eslint-plugin-shopify/blob/master/lib/rules/typescript/prefer-pascal-case-enums.js
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Import spruce paths using a hash #',
+			category: 'Stylistic Issues',
+			recommended: false
+		},
+		fixable: 'code'
+	},
+	create(context) {
+		return {
+			ImportDeclaration(options) {
+				const node = options.source
+				const importPath = node.value
+				if (/\.spruce/.test(importPath)) {
+						context.report({
+							node,
+							message: 'Import should use the #spruce/ syntax',
+							fix: function(fixer) {
+								const newImportPath = importPath.replace(/.*\.spruce/, '#spruce')
+								return fixer.replaceText(node, `'${newImportPath}'`);
+							}
+						})
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Adds a new rule that will error if it detects `.spruce` in an import statement
  * Fixable!
* Update pascal rule to be fixable