### PR TITLE
fix: variables before functions (accessor agnostic)

### DIFF
--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -63,7 +63,15 @@ const defaultFormattingRules = {
 		{
 			"classPropertiesAllowed": true
 		}
-	]
+	],
+	"sort-class-members/sort-class-members": [2, {
+		"order": [
+			"[properties]",
+			"constructor",
+			"[methods]"
+		],
+		"accessorPairPositioning": "getThenSet",
+	}]
 }
 
 module.exports = {
@@ -100,27 +108,6 @@ module.exports = {
 						}
 					}
 				],
-				'@typescript-eslint/member-ordering': [
-					'error',
-					{
-						order: [
-							'public-static-field',
-							'protected-static-field',
-							'private-static-field',
-							'public-instance-field',
-							'protected-instance-field',
-							'private-instance-field',
-							'constructor',
-							'public-static-method',
-							'protected-static-method',
-							'private-static-method',
-							'public-instance-method',
-							'protected-instance-method',
-							'private-instance-method'
-						],
-						alphabetize: true
-					}
-				],
 				"@typescript-eslint/explicit-member-accessibility": ["error"],
 				...defaultFormattingRules
 			}
@@ -136,7 +123,7 @@ module.exports = {
 		'eslint:recommended',
 		'prettier'
 	],
-	plugins: ['spruce', 'import', 'react', 'prettier', 'prefer-arrow-functions'],
+	plugins: ['spruce', 'import', 'react', 'prettier', 'prefer-arrow-functions', 'sort-class-members'],
 	rules: {
 		...defaultFormattingRules
 	},

--- a/packages/eslint-config-spruce/package.json
+++ b/packages/eslint-config-spruce/package.json
@@ -27,6 +27,7 @@
 		"eslint-plugin-prefer-arrow-functions": "^3.0.1",
 		"eslint-plugin-prettier": "^3.1.1",
 		"eslint-plugin-react": "^7.16.0",
+		"eslint-plugin-sort-class-members": "^1.7.0",
 		"eslint-plugin-spruce": "^10.4.0"
 	},
 	"peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,11 @@ eslint-plugin-react@^7.16.0:
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
 
+eslint-plugin-sort-class-members@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.7.0.tgz#82b8bfd1bf4bf4a4766b67e816359085a49b1dc3"
+  integrity sha512-p9VeMf4lwJs4VJ9jDJRadXPklNGIdUYxeCLi0tjF3F83KNC6CfX+c3H2h0DQ2yLl3hgKf0j6s3wGpZUuRYToeA==
+
 eslint-scope@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"


### PR DESCRIPTION
member-ordering seems to always want to control the order based on accessor, using the more generic configurations ['field', 'constructor', 'method'] still sorted on accessor based on the default ordering.

sort-class-members is only as specific as the configuration. 
