### PR TITLE
fix: arrows above methods

### DIFF
--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -62,6 +62,7 @@ const defaultFormattingRules = {
 		"order": [
 			"[properties]",
 			"constructor",
+			"[arrow-function-properties]",
 			"[methods]"
 		],
 		"accessorPairPositioning": "getThenSet",


### PR DESCRIPTION
The way the sort-class-members works doesn't allow co-mingling of arrow functions (properties) with regular methods.  For now sort them closer to each other and figure out a longer term solution.